### PR TITLE
Add manual install of build essential package

### DIFF
--- a/containers/agdmhs/Dockerfile
+++ b/containers/agdmhs/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Andrew Gainer-Dewar, Ph.D. <andrew.gainer.dewar@gmail.com>
 # Add any algorithm dependencies here
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+    build-essential \
     libboost-log-dev \
     libboost-program-options-dev \
     libboost-system-dev \


### PR DESCRIPTION
For `make`, `g++`, etc. which are required. Without this, the build step fails at `make`